### PR TITLE
Pass the request context instead of a fresh root context

### DIFF
--- a/microweb.go
+++ b/microweb.go
@@ -146,7 +146,6 @@ package {{ package . }}
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -189,7 +188,7 @@ func (h *web{{ $svc.Name }}Handler) {{ name . }}(w http.ResponseWriter, r *http.
 	{{- end }}
 
 	if err := h.h.{{ name . }}(
-		context.Background(),
+		r.Context(),
 		req,
 		resp,
 	); err != nil {


### PR DESCRIPTION
Change code generation to pass the request context into the handler instead of a fresh root context. This allows us to use middleware which modifies the context.