### PR TITLE
Include an option to add an ignore list not to generate some packages

### DIFF
--- a/microweb.go
+++ b/microweb.go
@@ -61,8 +61,23 @@ func (p *MicroWebModule) Name() string {
 }
 
 func (p *MicroWebModule) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Package) []pgs.Artifact {
+	ignored_packages := map[string]bool{}
+
+	params := p.ctx.Params()
+	if value, ok := params["ignore_packages"]; ok {
+		for _, ignored_pkg := range strings.Split(value, ";") {
+			ignored_packages[ignored_pkg] = true
+		}
+	}
+
 	for _, t := range targets {
-		p.generate(t)
+		packageName := t.Package().ProtoName().String()
+		fileName := t.Name().String()
+		if !ignored_packages[packageName] {
+			p.generate(t)
+		} else {
+			p.Debugf("Ignoring filename %s because it belongs to the ignored package %s", fileName, packageName)
+		}
 	}
 
 	return p.Artifacts()


### PR DESCRIPTION
Added the `ignore_packages` option to exclude those packages from being generated with this microweb generator.

The list is ";"-separated, such as `ignore_packages=pkg1;pkg2;pkg3`. The list will be split having the ";" as separator.
Note that having a trailing ";" will cause an empty package name to be part of the ignored list, which will mean that proto files without a declared package name will be ignored. Since this is usually an unwanted behavior, avoid that trailing ";"

The generator will perform an exact match against the declared package name. There is no fancy regex match in place, so you might need to list a long list of packages

Example usage with "buf" (buf.gen.yaml):
```
  - name: microweb
    path: ../../../protoc-gen-microweb/protoc-gen-microweb
    out: ../gen/
    opt:
      - paths=source_relative
      - "ignore_packages=\
         ocis.services.thumbnails.v1;\
         ocis.messages.thumbnails.v1"
```