### PR TITLE
ci: pin all GitHub Actions to SHA for org security policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go (with module and build cache)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
       - name: Cache googleapis repo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: googleapis
           key: ${{ runner.os }}-googleapis-cache


### PR DESCRIPTION
## Summary

Pins all GitHub Actions workflow steps to full commit SHAs to comply with the org's SHA-pinning policy.

## Test plan
- [ ] Verify CI workflows run successfully after the pin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)